### PR TITLE
fixed excludedUri remove function

### DIFF
--- a/src/apiHandler.js
+++ b/src/apiHandler.js
@@ -39,7 +39,7 @@ function getSwaggerSpec (req, res) {
 
   if (config.swaggerOptions.excludedUris.length) {
     config.swaggerOptions.excludedUris.filter(function (string) {
-      delete url[string];
+      delete urls[string];
     });
   }
 


### PR DESCRIPTION
wasn't referencing correct variable to remove excludedUri's from route documentation